### PR TITLE
Update sorting functionality to work with ResponsiveGrid render mode

### DIFF
--- a/src/components/sorting.ts
+++ b/src/components/sorting.ts
@@ -50,33 +50,48 @@ export default class Sorting {
 
     static DragSort(container) {
 
-        let isTable = container.is("tbody");
-        let items = isTable ? "> tr" : "> li"; // TODO: Do we need to support any other markup?
-
-        container.sortable({
+        var config = {
             handle: '[data-sort-item]',
-            items: items,
-            // As it causes a problem for moving items to the bottom of the list I have removed the containment.
-            // containment: "parent",
+            containment: "parent",
             axis: 'y',
-            helper: (e, ui) => {
-                // prevent TD collapse during drag
-                ui.children().each((i, c) => $(c).width($(c).width()));
-                return ui;
-            },
-            stop: (e, ui) => {
+            tolerance: "pointer",
+            scroll: true,
+        }
 
-                let dropBefore = ui.item.next().find("[data-sort-item]").attr("data-sort-item") || "";
+        var itemsSelector = "> li";
+        if (container.is("tbody")) {
+            itemsSelector = "> tr";
+        } else if (container.is(".r-grid-body")) {
+            itemsSelector = "> .r-grid-row";
+            delete config.axis;
+        }
 
-                let handle = ui.item.find("[data-sort-item]");
+        config["items"] = itemsSelector;
 
-                let actionUrl = handle.attr("data-sort-action");
-                actionUrl = Url.addQuery(actionUrl, "drop-before", dropBefore);
+        config["helper"] = (e, ui) => {
+            // prevent TD collapse during drag
+            ui.children().each((i, c) => $(c).width($(c).width()));
+            return ui;
+        };
+        config["stop"] = (e, ui) => {
 
-                actionUrl = Url.effectiveUrlProvider(actionUrl, handle);
+            $(ui).children().removeAttr("style");
+            container.find(itemsSelector).children().removeAttr("style");
 
-                FormAction.invokeWithAjax({ currentTarget: handle.get(0) }, actionUrl);
-            }
-        });
+            let dropBefore = ui.item.next().find("[data-sort-item]").attr("data-sort-item") || "";
+
+            let handle = ui.item.find("[data-sort-item]");
+
+            let actionUrl = handle.attr("data-sort-action");
+            actionUrl = Url.addQuery(actionUrl, "drop-before", dropBefore);
+
+            actionUrl = Url.effectiveUrlProvider(actionUrl, handle);
+
+            FormAction.invokeWithAjax({ currentTarget: handle.get(0) }, actionUrl);
+        };
+
+
+        container.sortable(config);
     }
+
 }

--- a/src/olivePage.ts
+++ b/src/olivePage.ts
@@ -95,7 +95,7 @@ export default class OlivePage {
         Grid.enableToggle($("th.select-all > input:checkbox"));
         MasterDetail.enable($("[data-delete-subform]"));
         Paging.enableOnSizeChanged($("form .pagination-size").find("select[name=p],select[name$='.p']"));
-        Sorting.enableDragSort($("[data-sort-item]").parents("tbody"));
+        Sorting.enableDragSort($("[data-sort-item]").parents("tbody,.r-grid-body"));
         Paging.enableWithAjax($("a[data-pagination]"));
         Sorting.enableAjaxSorting($("a[data-sort]"));
         Sorting.setSortHeaderClass($("th[data-sort]"));


### PR DESCRIPTION
olivePage.ts:
JQuery selector in line 98 updated to select responsive grids (.r-grid-body).

sorting.ts:
DragSort() method updated to enable jquery ui sortable on responsive grids (r-grid).
{ tolerance: 'pointer' } added to sortable config to make it easier for users to drag and drop items.
{ scroll: true } added to sortable config to make it easier for users to drag items in long lists.
Sortable:Stop event(Lines 78 and 79): Styles added to elements by jquery-ui sortable are removed when sorting is finished.