### PR TITLE
fix duplicate route in the action

### DIFF
--- a/src/mvc/standardAction.ts
+++ b/src/mvc/standardAction.ts
@@ -28,8 +28,21 @@ export default class StandardAction {
         let actions = [];
         $("input[name='Startup.Actions']", container).each((index, item) => {
             let action = $(item).val();
-            if (actions.indexOf(action) === -1)
-                actions.push(action);
+            if (actions.indexOf(action) === -1) {
+                //sometimes, we have a duplicate route in the action string, so we should remove them manually.
+                let names = action.trimStart("[{").trimEnd("}]").split("},{");
+                let uniqueNames = [];
+                $.each(names, (i, el) => {
+                    if($.inArray(el, uniqueNames) === -1) uniqueNames.push(el);
+                });
+                let stringResult = "[{";
+                $.each(uniqueNames,(i, itm)=> {
+                    stringResult += itm + "},{";
+                });
+                stringResult = stringResult.trimEnd(",{") + "]";
+                actions.push(stringResult);
+            }
+                
         });
 
         for (let action of actions) {


### PR DESCRIPTION
before these changes, if you directly navigate to a page, we had duplicate route value in the action variable, see this picture:

![1](https://user-images.githubusercontent.com/1321544/50284244-b3713d00-046d-11e9-9aa7-fb3217426a7d.jpg)

as you can see we had two canceled request which is caused by duplication in the route. I fixed this issue and you have this result:

![2](https://user-images.githubusercontent.com/1321544/50284298-db60a080-046d-11e9-8817-1965a30a6ab8.jpg)
