### PR TITLE
Handle stretching issue in custom radio button

### DIFF
--- a/src/plugins/customRadio.ts
+++ b/src/plugins/customRadio.ts
@@ -11,7 +11,8 @@ export default class CustomRadio {
     constructor(private input: JQuery) { }
 
     private enable() {
-        let radio = $('<div class="radio-helper"/>');
+        let radio = $('<div class="radio-helper"/>')
+            .append('<div class="radio-helper-inner"/>');
 
         let check = () => {
             if (this.input.attr('disabled')) return;


### PR DESCRIPTION
When options flow across multiple lines, this causes the 
button to stretch vertically. This can be managed by
appending an inner div to the radio helper div
![image](https://user-images.githubusercontent.com/15689258/115088860-0279f080-9f09-11eb-85e6-2e36b29976e0.png)
